### PR TITLE
Use peerDependencies instead of dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,9 +18,11 @@
   },
   "author": "kenny wong <wowohoo@qq.com>",
   "license": "MIT",
+  "peerDependencies": {
+    "parcel-bundler": "^1.12.3"
+  },
   "devDependencies": {},
   "dependencies": {
-    "marked": "^0.7.0",
-    "parcel-bundler": "^1.12.3"
+    "marked": "^0.7.0"
   }
 }


### PR DESCRIPTION
Hello !

First of all thanks a lot for this plugin 👍 

I think `parcel-bundler` should be a peerDependency instead of a dependency because it will install several versions of `parcel-bundler` for developers who updated `parcel-bundler`.

For example, I've got `parcel-bundler` version `1.12.4` and when I installed this plugin, my `yarn.lock` file shows me I've got `1.12.3` and `1.12.4` installed.