### PR TITLE
feat: add html option to output html assets

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
     "parcel": "^2.2.0"
   },
   "devDependencies": {
+    "@parcel/config-default": "^2.3.2",
+    "@parcel/core": "^2.3.2",
     "tsbb": "3.5.4"
   },
   "dependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,18 +26,24 @@ export default new Transformer({
           smartypants: false,
           xhtml: false,
         },
+        html: false,
         ...conf.contents as any,
       };
     }
   },
   async transform({ asset, config }) {
     let code = await asset.getCode();
-    const option: { marked?: marked.MarkedOptions } = config || {};
+    const option: { marked?: marked.MarkedOptions, html?: Boolean } = config || {};
     if (option.marked) {
       code = marked.parse(code, { ...option.marked });
     }
-    asset.type = 'js';
-    asset.setCode(`export default ${JSON.stringify(code)}`);
+    if (option.html && option.marked) {
+      asset.type = 'html';
+      asset.setCode(code);
+    } else {
+      asset.type = 'js';
+      asset.setCode(`export default ${JSON.stringify(code)}`);
+    }
     return [asset];
   },
 });


### PR DESCRIPTION
This allows the user to output HTML instead of an importable javascript

This also fixes interop when markdown contains images, etc