### PR TITLE
feat: adds sample config for html output

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,14 @@ npm install parcel-transformer-markdown --save-dev
 
 Import your markdown files! Output HTML string.
 
+
+```js
+// .markedrc
+{
+  "html": true
+}
+```
+
 ```js
 import HTMLStr from './Markdown.md';
 


### PR DESCRIPTION
I was unable to get an HTML string output unless I added `html: true` to my marked config file due to #9. This PR adds a sample config so others can quickly get an HTML string output.